### PR TITLE
Retry http PAR GETs

### DIFF
--- a/deploy/basic/terraform/scripts/node.sh
+++ b/deploy/basic/terraform/scripts/node.sh
@@ -62,8 +62,6 @@ sqlplus admin/$${ATP_PW}@$${ATP_DB_NAME}_tp @/root/catalogue.sql
 
 # Get http server config
 get_object /etc/httpd/conf/httpd.conf $${APACHE_CONF_URI}
-http_status=$(curl -w '%%{http_code}' -L -s -o /etc/httpd/conf/httpd.conf $${APACHE_CONF_URI})
-
 
 #Get binaries
 get_object /root/mushop-bin.tar.gz $${MUSHOP_APP_URI}


### PR DESCRIPTION
- switches to cURL for downloading the objects from the object storage.
- uses a single retry in case the initial request results in a non 200 response.
- cURL or wget does not retry 4xx errors even with the retry flags (those are for transient errors while an 404 is considered permanent)
